### PR TITLE
- moved the header parsing under the private parse method.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
+        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
     </properties>
 
     <dependencies>
@@ -169,6 +170,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/neotys/advanced/action/apache/kafka/connect/KafkaConnectActionTest.java
+++ b/src/test/java/com/neotys/advanced/action/apache/kafka/connect/KafkaConnectActionTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class KafkaConnectActionTest {
+class KafkaConnectActionTest {
     @Test
-    public void shouldReturnType() {
+    void shouldReturnType() {
         final KafkaConnectAction action = new KafkaConnectAction();
         assertEquals("KafkaConnect", action.getType());
     }

--- a/src/test/java/com/neotys/advanced/action/apache/kafka/disconnect/KafkaDisconnectActionTest.java
+++ b/src/test/java/com/neotys/advanced/action/apache/kafka/disconnect/KafkaDisconnectActionTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
-public class KafkaDisconnectActionTest {
+class KafkaDisconnectActionTest {
 	@Test
-	public void shouldReturnType() {
+	void shouldReturnType() {
 		final KafkaDisconnectAction action = new KafkaDisconnectAction();
 		assertEquals("KafkaDisconnect", action.getType());
 	}


### PR DESCRIPTION
- Modified To-String for friend printing
- Trimmed key and value within headers input string
- Removed edge case where header key is empty
- Allowed empty values in header.
- Added tests for above changes
- Added surefire plugin required for junit5 & maven.